### PR TITLE
Add Investec sandbox mode

### DIFF
--- a/modules/investec.js
+++ b/modules/investec.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const InvestecSandbox = require('./investec_sandbox')
 const logError = (error) => console.log(error.toJSON())
 
 // Simple adapter to fetch bearer tokens and proxy requests to Investec's API
@@ -9,6 +10,22 @@ class Investec {
 
   constructor(credentials) {
     this.credentials = credentials
+
+    if (this.isSandboxCredentials(credentials)) {
+      return new InvestecSandbox()
+    }
+  }
+
+  isSandboxCredentials(credentials) {
+    if (!credentials) { return false }
+    if (credentials === 'SANDBOX') { return true }
+
+    try {
+      const decoded = Buffer.from(credentials, 'base64').toString()
+      return decoded.split(':').includes('SANDBOX')
+    } catch {
+      return false
+    }
   }
 
   async getAuthToken() {

--- a/modules/investec_sandbox.js
+++ b/modules/investec_sandbox.js
@@ -1,0 +1,84 @@
+const accountId = 'sandbox-account-1'
+
+const accounts = [
+  {
+    accountId,
+    accountNumber: '10000000001',
+    accountName: 'SANDBOX Private Bank Account',
+    referenceName: 'SANDBOX',
+    productName: 'Private Bank Account'
+  }
+]
+
+const transactions = [
+  {
+    accountId,
+    type: 'DEBIT',
+    transactionType: 'CardPurchases',
+    status: 'POSTED',
+    description: 'SANDBOX COFFEE SHOP',
+    cardNumber: '400000******0001',
+    postedOrder: 1,
+    postingDate: '2024-01-15',
+    transactionDate: '2024-01-15',
+    actionDate: '2024-01-15',
+    transactionTime: '09:31:00',
+    amount: -4500,
+    runningBalance: 125500
+  },
+  {
+    accountId,
+    type: 'CREDIT',
+    transactionType: 'Deposit',
+    status: 'POSTED',
+    description: 'SANDBOX SALARY',
+    postedOrder: 2,
+    postingDate: '2024-01-01',
+    transactionDate: '2024-01-01',
+    actionDate: '2024-01-01',
+    transactionTime: '08:00:00',
+    amount: 130000,
+    runningBalance: 130000
+  }
+]
+
+function response(data, status = 200) {
+  return { status, data }
+}
+
+class InvestecSandbox {
+  async getWithAuth(path) {
+    if (path === '/za/pb/v1/accounts') {
+      return response({ data: { accounts } })
+    }
+
+    const transactionsMatch = path.match(/^\/za\/pb\/v1\/accounts\/([^/]+)\/transactions/)
+    if (transactionsMatch) {
+      const requestedAccountId = transactionsMatch[1]
+      return response({
+        data: {
+          transactions: transactions.filter(transaction => transaction.accountId === requestedAccountId)
+        }
+      })
+    }
+
+    return response({
+      data: {
+        message: 'Sandbox endpoint not implemented',
+        path
+      }
+    }, 404)
+  }
+
+  async postWithAuth(path, params) {
+    return response({
+      data: {
+        message: 'Sandbox POST endpoint not implemented',
+        path,
+        params
+      }
+    }, 404)
+  }
+}
+
+module.exports = InvestecSandbox


### PR DESCRIPTION
Refs #3

## Summary
- add an Investec sandbox adapter for the existing proxy layer
- detect sandbox credentials from either a literal `SANDBOX` credential or base64 `SANDBOX:...` / `...:SANDBOX` Basic auth payloads
- return sample Investec-shaped account and transaction responses from the same `/za/pb/v1/accounts` and `/za/pb/v1/accounts/:accountId/transactions` paths
- avoid calling the live Investec OAuth/API endpoints when sandbox credentials are used

## Validation
- `node -c modules/investec.js`
- `node -c modules/investec_sandbox.js`
- manual Node smoke test instantiating `new Investec(Buffer.from('SANDBOX:SANDBOX').toString('base64'))`, then fetching `/za/pb/v1/accounts` and `/za/pb/v1/accounts/sandbox-account-1/transactions` successfully returned sandbox data

Note: this repository has no runnable test script configured (`npm test` exits with the default placeholder).