### PR TITLE
Fix sandbox routing for Investec proxy

### DIFF
--- a/modules/investec.js
+++ b/modules/investec.js
@@ -61,7 +61,7 @@ class Investec {
   }
 
   async get(path) {
-    await axios.get(path, this.axiosConfig()).catch(logError)
+    return await axios.get(path, this.axiosConfig()).catch(logError)
   }
 
   async getWithAuth(path) {

--- a/modules/investec.js
+++ b/modules/investec.js
@@ -1,6 +1,9 @@
 const axios = require('axios')
 const InvestecSandbox = require('./investec_sandbox')
-const logError = (error) => console.log(error.toJSON())
+const logError = (error) => {
+  console.log(error.toJSON ? error.toJSON() : error)
+  return error.response
+}
 
 // Simple adapter to fetch bearer tokens and proxy requests to Investec's API
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node tests/sandbox-smoke.js"
   },
   "keywords": [],
   "author": "",

--- a/routes/investec.js
+++ b/routes/investec.js
@@ -6,6 +6,14 @@ router.use('/special', require('./investec/special'))
 const Investec = require('../modules/investec')
 const cardPartitions = require('./investec/card_partitions')
 
+function sendInvestecResponse(_res, response) {
+  if (!response) {
+    return _res.status(502).json({ error: 'No response received from Investec API' })
+  }
+
+  return _res.status(response.status || 200).json(response.data)
+}
+
 // This route is not a pure proxy because we want to filter the results if there is a partition i.e. when sharing a single account with many users while only showing them particular cards
 router.get('/za/v1/cards', async (_req, _res) => {
   const investec = new Investec(_req.currentUser.token)
@@ -31,7 +39,7 @@ router.get('/za/v1/cards', async (_req, _res) => {
 router.get('/*', async (_req, _res) => {
   const investec = new Investec(_req.currentUser.token)
   const response = await investec.getWithAuth(_req.url)
-  _res.status(response.status || 200).json(response.data)
+  sendInvestecResponse(_res, response)
 })
 
 // proxies any POST request to the investec adapter
@@ -39,7 +47,7 @@ router.get('/*', async (_req, _res) => {
 router.post('/*', async (_req, _res) => {
   const investec = new Investec(_req.currentUser.token)
   const response = await investec.postWithAuth(_req.url, _req.body)
-  _res.status(response.status || 200).json(response.data)
+  sendInvestecResponse(_res, response)
 })
 
 module.exports = router

--- a/routes/investec.js
+++ b/routes/investec.js
@@ -31,7 +31,7 @@ router.get('/za/v1/cards', async (_req, _res) => {
 router.get('/*', async (_req, _res) => {
   const investec = new Investec(_req.currentUser.token)
   const response = await investec.getWithAuth(_req.url)
-  _res.json(response.data)
+  _res.status(response.status || 200).json(response.data)
 })
 
 // proxies any POST request to the investec adapter
@@ -39,7 +39,7 @@ router.get('/*', async (_req, _res) => {
 router.post('/*', async (_req, _res) => {
   const investec = new Investec(_req.currentUser.token)
   const response = await investec.postWithAuth(_req.url, _req.body)
-  _res.json(response.data)
+  _res.status(response.status || 200).json(response.data)
 })
 
 module.exports = router

--- a/routes/investec/auth.js
+++ b/routes/investec/auth.js
@@ -6,10 +6,10 @@ function splitPartitionFromToken(partitionedToken) {
     return { token: "SANDBOX", username: "SANDBOX", partition: undefined }
   }
 
-  const partitionedCredentials = new Buffer(partitionedToken, 'base64').toString()
+  const partitionedCredentials = Buffer.from(partitionedToken, 'base64').toString()
   const [partitionedUsername, password] = partitionedCredentials.split(":")
   const [username, partition] = partitionedUsername.split("/")
-  const token = (new Buffer.from(`${username}:${password}`)).toString('base64')
+  const token = Buffer.from(`${username}:${password}`).toString('base64')
   return { token, username, partition }
 }
 

--- a/routes/investec/auth.js
+++ b/routes/investec/auth.js
@@ -2,6 +2,9 @@ function splitPartitionFromToken(partitionedToken) {
   // pulls out an optional partition (subfolder) from API credentials
   // which is used when filtering Investec API responses to show only
   // certain cards
+  if (partitionedToken == "SANDBOX") {
+    return { token: "SANDBOX", username: "SANDBOX", partition: undefined }
+  }
 
   const partitionedCredentials = new Buffer(partitionedToken, 'base64').toString()
   const [partitionedUsername, password] = partitionedCredentials.split(":")
@@ -16,7 +19,6 @@ function getAuth(_req, _res, next) {
   if (authType == "Basic") {
     let { token, username, partition } = splitPartitionFromToken(partitionedToken)
     _req.currentUser = { username, partition, token }
-    console.log(_req.currentUser)
   }
 
   if (authType == "RootCard") {

--- a/tests/sandbox-smoke.js
+++ b/tests/sandbox-smoke.js
@@ -1,0 +1,41 @@
+const assert = require('assert')
+const Investec = require('../modules/investec')
+const getAuth = require('../routes/investec/auth')
+
+async function testSandboxAdapter() {
+  const sandbox = new Investec('SANDBOX')
+
+  const accountsResponse = await sandbox.getWithAuth('/za/pb/v1/accounts')
+  assert.strictEqual(accountsResponse.status, 200)
+  assert.strictEqual(accountsResponse.data.data.accounts.length, 1)
+
+  const accountId = accountsResponse.data.data.accounts[0].accountId
+  const transactionsResponse = await sandbox.getWithAuth(`/za/pb/v1/accounts/${accountId}/transactions`)
+  assert.strictEqual(transactionsResponse.status, 200)
+  assert.strictEqual(transactionsResponse.data.data.transactions.length, 2)
+
+  const missingResponse = await sandbox.getWithAuth('/za/pb/v1/cards')
+  assert.strictEqual(missingResponse.status, 404)
+  assert.strictEqual(missingResponse.data.data.path, '/za/pb/v1/cards')
+}
+
+function testSandboxAuthHeader() {
+  const req = {
+    headers: { authorization: 'Basic SANDBOX' }
+  }
+
+  getAuth(req, {}, () => {})
+
+  assert.deepStrictEqual(req.currentUser, {
+    username: 'SANDBOX',
+    partition: undefined,
+    token: 'SANDBOX'
+  })
+}
+
+async function run() {
+  await testSandboxAdapter()
+  testSandboxAuthHeader()
+}
+
+run()


### PR DESCRIPTION
Closes #3.

## Summary

This PR tightens the existing sandbox mode path so consumers can use the same Investec proxy routes with sandbox credentials for accounts and transactions.

## What changed

- Allows `Basic SANDBOX` through the Investec auth middleware without trying to base64-decode it as real credentials.
- Preserves adapter response status codes in the generic GET/POST proxy routes, so sandbox 404 responses are returned as 404 instead of always 200.
- Returns the upstream response from `Investec#get`, matching the authenticated helpers.
- Removes a credential-bearing auth debug log from the middleware.
- Adds a small smoke test for sandbox accounts, sandbox transactions, missing sandbox endpoints, and `Basic SANDBOX` auth parsing.

## Testing

- `npm test`
- `node -c modules/investec.js; node -c modules/investec_sandbox.js; node -c routes/investec.js; node -c routes/investec/auth.js; node -c tests/sandbox-smoke.js`